### PR TITLE
remove Consent LOINC code. 

### DIFF
--- a/input/fsh/research-consent-instance.fsh
+++ b/input/fsh/research-consent-instance.fsh
@@ -25,7 +25,6 @@ Taking part in this study is up to you. You may decide not to take part or you m
 
 * provision[1].action = #access
 * provision[1].resourceType = #Observation
-* provision[1].code[0] = $SCT#887031000000108 "Consent for information sharing"
 * provision[1].code[1] = $LOINC#LP14443-3 "CD4"
 * provision[1].code[2] = $LOINC#48511-0 "HIV viral load"
 * provision[1].extension[actionPurpose][0].valueCodeableReference.concept.text = """


### PR DESCRIPTION
the consent code does not belong here. Maybe it's appropriate to use this code as the category of the consent but it doesn't belong in the provisions because it will have the misleading meaning that the access is being granted to patient's consent information (instead of observations etc.)